### PR TITLE
Include main SQL class only if necessary

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -23,11 +23,18 @@ class vision_intranet::database (
 ) {
 
   if !defined(Class['::vision_mysql::server']) {
-    class { '::vision_mysql::server':
-      root_password => $mysql_root_password,
-      backup        => {
-        databases => [$mysql_intranet_database],
-        password  => $mysql_backup_password,
+    # no backups in staging environment
+    if $::applicationtier == 'staging' {
+      class { '::vision_mysql::server':
+        root_password => $mysql_root_password,
+      }
+    } else {
+      class { '::vision_mysql::server':
+        root_password => $mysql_root_password,
+        backup        => {
+          databases => [$mysql_intranet_database],
+          password  => $mysql_backup_password,
+        }
       }
     }
   }

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -17,7 +17,6 @@ class vision_intranet::database (
   String $mysql_intranet_database = $vision_intranet::mysql_intranet_database,
   String $mysql_intranet_password = $vision_intranet::mysql_intranet_password,
   String $mysql_intranet_user = $vision_intranet::mysql_intranet_user,
-  Optional[String] $mysql_monitoring_password = $vision_intranet::mysql_monitoring_password,
   Optional[String] $mysql_root_password = $vision_intranet::mysql_root_password,
   Optional[String] $mysql_backup_password = $vision_intranet::mysql_backup_password,
 
@@ -26,9 +25,6 @@ class vision_intranet::database (
   if !defined(Class['::vision_mysql::server']) {
     class { '::vision_mysql::server':
       root_password => $mysql_root_password,
-      monitoring    => {
-        password => $mysql_monitoring_password,
-      },
       backup        => {
         databases => [$mysql_intranet_database],
         password  => $mysql_backup_password,

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -13,23 +13,26 @@
 
 class vision_intranet::database (
 
-  String $mysql_backup_password     = $vision_intranet::mysql_backup_password,
-  String $mysql_intranet_database   = $vision_intranet::mysql_intranet_database,
-  String $mysql_intranet_password   = $vision_intranet::mysql_intranet_password,
-  String $mysql_intranet_user       = $vision_intranet::mysql_intranet_user,
-  String $mysql_monitoring_password = $vision_intranet::mysql_monitoring_password,
-  String $mysql_root_password       = $vision_intranet::mysql_root_password,
+
+  String $mysql_intranet_database = $vision_intranet::mysql_intranet_database,
+  String $mysql_intranet_password = $vision_intranet::mysql_intranet_password,
+  String $mysql_intranet_user = $vision_intranet::mysql_intranet_user,
+  Optional[String] $mysql_monitoring_password = $vision_intranet::mysql_monitoring_password,
+  Optional[String] $mysql_root_password = $vision_intranet::mysql_root_password,
+  Optional[String] $mysql_backup_password = $vision_intranet::mysql_backup_password,
 
 ) {
 
-  class { '::vision_mysql::server':
-    root_password => $mysql_root_password,
-    monitoring    => {
-      password => $mysql_monitoring_password,
-    },
-    backup        => {
-      databases => [$mysql_intranet_database],
-      password  => $mysql_backup_password,
+  if !defined(Class['::vision_mysql::server']) {
+    class { '::vision_mysql::server':
+      root_password => $mysql_root_password,
+      monitoring    => {
+        password => $mysql_monitoring_password,
+      },
+      backup        => {
+        databases => [$mysql_intranet_database],
+        password  => $mysql_backup_password,
+      }
     }
   }
 
@@ -38,6 +41,7 @@ class vision_intranet::database (
     password => $mysql_intranet_password,
     host     => '%',
     grant    => ['ALL'],
+    require  => Class['::vision_mysql::server'],
   }
 
 }

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -14,8 +14,6 @@
 class vision_intranet::docker (
 
   String $mysql_root_password       = $vision_intranet::mysql_root_password,
-  String $mysql_monitoring_password = $vision_intranet::mysql_monitoring_password,
-  String $mysql_backup_password     = $vision_intranet::mysql_backup_password,
   String $mysql_intranet_database   = $vision_intranet::mysql_intranet_database,
   String $mysql_intranet_user       = $vision_intranet::mysql_intranet_user,
   String $mysql_intranet_password   = $vision_intranet::mysql_intranet_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,6 @@ class vision_intranet (
   Array  $docker_volumes = [],
   Integer $port = 80,
   Optional[String] $mysql_root_password,
-  Optional[String] $mysql_monitoring_password,
   Optional[String] $mysql_backup_password,
 
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,14 +13,14 @@
 
 class vision_intranet (
 
-  String $mysql_root_password,
-  String $mysql_monitoring_password,
-  String $mysql_backup_password,
   String $mysql_intranet_database,
   String $mysql_intranet_user,
   String $mysql_intranet_password,
   Array  $docker_volumes = [],
   Integer $port = 80,
+  Optional[String] $mysql_root_password,
+  Optional[String] $mysql_monitoring_password,
+  Optional[String] $mysql_backup_password,
 
 ) {
 

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -18,7 +18,6 @@ describe 'vision_intranet' do
 
         class { 'vision_intranet':
             mysql_root_password => 'foobar',
-            mysql_monitoring_password => 'foobar',
             mysql_backup_password => 'foobar',
             mysql_intranet_database => 'intranet',
             mysql_intranet_user => 'userint',

--- a/spec/classes/compile_spec.rb
+++ b/spec/classes/compile_spec.rb
@@ -5,7 +5,10 @@ describe 'vision_intranet' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts.merge(root_home: '/root')
+        facts.merge(
+          root_home: '/root',
+          applicationtier: 'production'
+        )
       end
 
       context 'compile' do


### PR DESCRIPTION
required when both vision_intranet and vision_webshop modules are
contained in a role, resulting in a duplicate declaration conflict